### PR TITLE
no more weapon boxes in pacifist run

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -971,6 +971,10 @@ const addFlames = (position, rotation, parent) => {
 };
 
 const addPowerup = (type, position, rotation, velocity, angularVelocity) => {
+  if (!weaponsEnabled && ["damage", "rocket-piercing"].includes(type)) {
+    return;
+  }
+  
   const powerup = createPhysicsEntity();
   powerup.type = type;
   powerup.position = position;


### PR DESCRIPTION
fixes a "bug" which causes useless weapon boxes to spawn in pacifist mode.

This is fixed by checking the type of a box on spawn, if the type is either "damage" or "rocket-piercing" the box is not spawned.

Therefore there are the same amount of health boxes.

If you want this merge it, i am not so sure if you want it but here it is!